### PR TITLE
Bug fix: Actually use overridden config.writePath value

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -84,7 +84,7 @@ Keen.prototype.url = function(path, data){
     this.emit('error', 'Keen is missing a projectId property');
     return;
   }
-  url = this.config.protocol + '://' + this.config.host + '/3.0/projects/' + this.projectId();
+  url = this.config.protocol + '://' + this.config.host + this.writePath();
   if (path) {
     url += path;
   }

--- a/lib/record-events-browser.js
+++ b/lib/record-events-browser.js
@@ -21,7 +21,7 @@ module.exports = {
 function recordEvent(eventCollection, eventBody, callback){
   var url, data, cb, getRequestUrl, extendedEventBody;
 
-  url = this.url('/events/' + encodeURIComponent(eventCollection));
+  url = this.url('/' + encodeURIComponent(eventCollection));
   data = {};
   cb = callback;
 
@@ -62,7 +62,7 @@ function recordEvent(eventCollection, eventBody, callback){
   // Send event
   // ------------------------------
 
-  getRequestUrl = this.url('/events/' + encodeURIComponent(eventCollection), {
+  getRequestUrl = this.url('/' + encodeURIComponent(eventCollection), {
     api_key  : this.writeKey(),
     data     : base64.encode(JSON2.stringify(extendedEventBody)),
     modified : new Date().getTime()
@@ -101,7 +101,7 @@ function recordEvent(eventCollection, eventBody, callback){
 function recordEvents(eventsHash, callback){
   var self = this, url, cb, extendedEventsHash;
 
-  url = this.url('/events');
+  url = this.url();
   cb = callback;
   callback = null;
 

--- a/lib/record-events-server.js
+++ b/lib/record-events-server.js
@@ -22,7 +22,6 @@ module.exports = {
 function recordEvent(eventCollection, eventBody, callback){
   var url, data, cb, extendedEventBody;
 
-  url = this.url('/events/' + encodeURIComponent(eventCollection));
   data = {};
   cb = callback;
   callback = null;
@@ -74,7 +73,6 @@ function recordEvent(eventCollection, eventBody, callback){
 function recordEvents(eventsHash, callback){
   var self = this, url, cb, extendedEventsHash;
 
-  url = this.url('/events');
   cb = callback;
   callback = null;
 

--- a/test/unit/modules/client-spec.js
+++ b/test/unit/modules/client-spec.js
@@ -9,16 +9,19 @@ describe('Keen (browser)', function() {
   beforeEach(function() {
     this.client = new Keen({
       projectId: config.projectId,
-      writeKey: config.writeKey,
-      protocol: config.protocol,
-      host: config.host
+      writeKey: config.writeKey
     });
-    this.matchUrlBase = config.protocol + '://' + config.host + '/3.0/projects/' + config.projectId;
+  });
 
-    // Hack for IE9 request shim
-    if ('undefined' !== typeof document && document.all) {
-      this.matchUrlBase = this.matchUrlBase.replace('https', 'http');
-    }
+  describe('client defaults', function() {
+
+    it('should have sensible values', function(){
+      assert.equal(this.client.config.host, 'api.keen.io');
+      //assert.equal(this.client.config.protocol, 'https');
+      assert.equal(this.client.config.requestType, 'jsonp');
+      assert.equal(this.client.writePath(), '/3.0/projects/' + config.projectId + '/events');
+    });
+
   });
 
   describe('#configure', function(){
@@ -28,17 +31,28 @@ describe('Keen (browser)', function() {
         projectId: '123',
         writeKey: '456',
         protocol: 'http',
-        host: 'none'
+        host: 'none',
+        writePath: '/customWritePath'
       });
       assert.equal(this.client.projectId(), '123');
       assert.equal(this.client.writeKey(), '456');
-      assert.equal(this.client.config.protocol, 'http');
       assert.equal(this.client.config.host, 'none');
+      assert.equal(this.client.config.protocol, 'http');
+      assert.equal(this.client.writePath(), '/customWritePath');
     });
 
   });
 
   describe('#url', function(){
+
+    beforeEach(function() {
+      this.matchUrlBase = this.client.config.protocol + '://' + this.client.config.host + this.client.writePath();
+
+      // Hack for IE9 request shim
+      if ('undefined' !== typeof document && document.all) {
+        this.matchUrlBase = this.matchUrlBase.replace('https', 'http');
+      }
+    });
 
     it('should return a base URL when no arguments are provided', function(){
       assert.equal(this.client.url(), this.matchUrlBase);


### PR DESCRIPTION
**What does this PR do?**

This PR fixes a bug with config.writePath behaviour. 

The Readme states that config.writePath can be overwritten from its default value of '/3.0/projects/YOUR_PROJECT_ID/events', and that the value is used in recordEvent calls to the Keen/Keen-proxy end-point. This was not the case.

The fix was to change the Keen.prototype.url function to actually use the this.writePath() value. I also updated calls to url(), removing the '/events' path parameter (that's really the suffix of the writePath() value). Finally, I added some tests to show what the expected config default values are.

Cheers :-)

Greg

**How should this be tested? (if appropriate)**

* run gulp with-tests
* confirm tests pass

**Are there any related issues open?**

No.