### PR TITLE
Maintain keen-js behaviour: Only use browser xhr POST not GET

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -84,7 +84,7 @@ Keen.prototype.url = function(path, data){
     this.emit('error', 'Keen is missing a projectId property');
     return;
   }
-  url = this.config.protocol + '://' + this.config.host + '/3.0/projects/' + this.projectId();
+  url = this.config.protocol + '://' + this.config.host + this.writePath();
   if (path) {
     url += path;
   }

--- a/lib/record-events-browser.js
+++ b/lib/record-events-browser.js
@@ -21,7 +21,7 @@ module.exports = {
 function recordEvent(eventCollection, eventBody, callback){
   var url, data, cb, getRequestUrl, extendedEventBody;
 
-  url = this.url('/events/' + encodeURIComponent(eventCollection));
+  url = this.url('/' + encodeURIComponent(eventCollection));
   data = {};
   cb = callback;
 
@@ -62,7 +62,7 @@ function recordEvent(eventCollection, eventBody, callback){
   // Send event
   // ------------------------------
 
-  getRequestUrl = this.url('/events/' + encodeURIComponent(eventCollection), {
+  getRequestUrl = this.url('/' + encodeURIComponent(eventCollection), {
     api_key  : this.writeKey(),
     data     : base64.encode(JSON2.stringify(extendedEventBody)),
     modified : new Date().getTime()
@@ -101,7 +101,7 @@ function recordEvent(eventCollection, eventBody, callback){
 function recordEvents(eventsHash, callback){
   var self = this, url, cb, extendedEventsHash;
 
-  url = this.url('/events');
+  url = this.url();
   cb = callback;
   callback = null;
 

--- a/lib/record-events-browser.js
+++ b/lib/record-events-browser.js
@@ -19,7 +19,7 @@ module.exports = {
 // ------------------------------
 
 function recordEvent(eventCollection, eventBody, callback){
-  var url, data, cb, getRequestUrl, extendedEventBody;
+  var url, data, cb, getRequestUrl, getRequestUrlOkLength, extendedEventBody;
 
   url = this.url('/' + encodeURIComponent(eventCollection));
   data = {};
@@ -67,32 +67,35 @@ function recordEvent(eventCollection, eventBody, callback){
     data     : base64.encode(JSON2.stringify(extendedEventBody)),
     modified : new Date().getTime()
   });
+  getRequestUrlOkLength = getRequestUrl.length < getUrlMaxLength();
 
-  if (getRequestUrl.length < getUrlMaxLength()) {
-    switch (this.config.requestType) {
-      case 'xhr':
-        sendXhr.call(this, 'GET', getRequestUrl, null, null, cb);
-        break;
-      case 'beacon':
+  switch (this.config.requestType) {
+    case 'xhr':
+      sendXhr.call(this, 'POST', url, extendedEventBody, cb);
+      break;
+    case 'beacon':
+      if (getRequestUrlOkLength) {
         sendBeacon.call(this, getRequestUrl, cb);
-        break;
-      default:
+      }
+      else {
+        attemptPostXhr.call(this, url, extendedEventBody,
+            'Beacon URL length exceeds current browser limit, and XHR is not supported.', cb)
+      }
+      break;
+    default:
+      if (getRequestUrlOkLength) {
         sendJSONp.call(this, getRequestUrl, cb);
-        break;
-    }
-  }
-  else if (getXhr()) {
-    sendXhr.call(this, 'POST', url, extendedEventBody, cb);
-  }
-  else {
-    handleValidationError.call(this, 'URL length exceeds current browser limit, and XHR is not supported.');
+      }
+      else {
+        attemptPostXhr.call(this, url, extendedEventBody,
+            'JSONp URL length exceeds current browser limit, and XHR is not supported.', cb)
+      }
+      break;
   }
 
   callback = cb = null;
   return this;
 }
-
-
 
 // ------------------------------
 // .recordEvents
@@ -235,6 +238,15 @@ function getUrlMaxLength(){
 // ------------------------------
 // XHR Requests
 // ------------------------------
+
+function attemptPostXhr(url, data, noXhrError, callback) {
+  if (getXhr()) {
+    sendXhr.call(this, 'POST', url, data, callback);
+  }
+  else {
+    handleValidationError.call(this, noXhrError);
+  }
+}
 
 function sendXhr(method, url, data, callback){
   var self = this;

--- a/lib/record-events-server.js
+++ b/lib/record-events-server.js
@@ -22,7 +22,6 @@ module.exports = {
 function recordEvent(eventCollection, eventBody, callback){
   var url, data, cb, extendedEventBody;
 
-  url = this.url('/events/' + encodeURIComponent(eventCollection));
   data = {};
   cb = callback;
   callback = null;
@@ -74,7 +73,6 @@ function recordEvent(eventCollection, eventBody, callback){
 function recordEvents(eventsHash, callback){
   var self = this, url, cb, extendedEventsHash;
 
-  url = this.url('/events');
   cb = callback;
   callback = null;
 

--- a/test/unit/modules/client-spec.js
+++ b/test/unit/modules/client-spec.js
@@ -9,16 +9,19 @@ describe('Keen (browser)', function() {
   beforeEach(function() {
     this.client = new Keen({
       projectId: config.projectId,
-      writeKey: config.writeKey,
-      protocol: config.protocol,
-      host: config.host
+      writeKey: config.writeKey
     });
-    this.matchUrlBase = config.protocol + '://' + config.host + '/3.0/projects/' + config.projectId;
+  });
 
-    // Hack for IE9 request shim
-    if ('undefined' !== typeof document && document.all) {
-      this.matchUrlBase = this.matchUrlBase.replace('https', 'http');
-    }
+  describe('client defaults', function() {
+
+    it('should have sensible values', function(){
+      assert.equal(this.client.config.host, 'api.keen.io');
+      //assert.equal(this.client.config.protocol, 'https');
+      assert.equal(this.client.config.requestType, 'jsonp');
+      assert.equal(this.client.writePath(), '/3.0/projects/' + config.projectId + '/events');
+    });
+
   });
 
   describe('#configure', function(){
@@ -28,17 +31,28 @@ describe('Keen (browser)', function() {
         projectId: '123',
         writeKey: '456',
         protocol: 'http',
-        host: 'none'
+        host: 'none',
+        writePath: '/customWritePath'
       });
       assert.equal(this.client.projectId(), '123');
       assert.equal(this.client.writeKey(), '456');
-      assert.equal(this.client.config.protocol, 'http');
       assert.equal(this.client.config.host, 'none');
+      assert.equal(this.client.config.protocol, 'http');
+      assert.equal(this.client.writePath(), '/customWritePath');
     });
 
   });
 
   describe('#url', function(){
+
+    beforeEach(function() {
+      this.matchUrlBase = this.client.config.protocol + '://' + this.client.config.host + this.client.writePath();
+
+      // Hack for IE9 request shim
+      if ('undefined' !== typeof document && document.all) {
+        this.matchUrlBase = this.matchUrlBase.replace('https', 'http');
+      }
+    });
 
     it('should return a base URL when no arguments are provided', function(){
       assert.equal(this.client.url(), this.matchUrlBase);

--- a/test/unit/modules/record-events-browser-spec.js
+++ b/test/unit/modules/record-events-browser-spec.js
@@ -19,7 +19,7 @@ describe('.recordEvent(s) methods (browser)', function() {
         host: config.host,
         protocol: config.protocol
       });
-      this.postUrl = this.client.url('/events/' + config.collection);
+      this.postUrl = this.client.url('/' + config.collection);
 
       // Hack for IE9 request shim
       if ('undefined' !== typeof document && document.all) {
@@ -52,7 +52,7 @@ describe('.recordEvent(s) methods (browser)', function() {
 
       it('should send a GET request to the API using XHR', function() {
         var count = 0;
-        this.server.respondWith( 'GET', this.postUrl, [ 200, { 'Content-Type': 'application/json'}, config.responses['success'] ] );
+        this.server.respondWith( 'POST', this.postUrl, [ 200, { 'Content-Type': 'application/json'}, config.responses['success'] ] );
         this.client.recordEvent(config.collection, config.properties, function(err, res){
           count++;
           assert.isNull(err);
@@ -69,7 +69,7 @@ describe('.recordEvent(s) methods (browser)', function() {
           // assert.deepEqual(err, JSON.parse(config.responses['error']));
           assert.isNull(res);
         });
-        this.server.respondWith( 'GET', this.postUrl, [ 500, { 'Content-Type': 'application/json'}, config.responses['error'] ] );
+        this.server.respondWith( 'POST', this.postUrl, [ 500, { 'Content-Type': 'application/json'}, config.responses['error'] ] );
         this.server.respond();
       });
 


### PR DESCRIPTION
**What does this PR do?**

WARNING: This PR builds on a previous 'bug' PR I submitted today: https://github.com/keen/keen-tracking.js/pull/26. I'm opening this PR as well, to highlight some extra behavioural changes that might be worth making before a 0.0.2 release. If you're happy with this PR's behavioural changes, then feel free to merge them in asap. Alternatively, if you do merge in the [first 'bug' PR](https://github.com/keen/keen-tracking.js/pull/26) alone, I can rebase this PR on top (on Monday).

This PR changes the browser recordEvent function behaviour when config.requestType is 'xhr':
* To (new behaviour):  _only_ use XHR POST requests, regardless of payload length
* From (current behaviour): use XHR GET if payload length < 16000 chars, else POST.

Reasoning:
* The older keen-js library [only uses XHR POST requests](https://github.com/keen/keen-js/blob/940ca049d02cff10083e5d887222846f73bd9e67/src/core/lib/addEvent.js). So this PR ensures compatible behaviour between keen-js and keen-tracking.
* It's simpler, as requestType == 'xhr' only has one type of behaviour (POST only). This means it's easier to proxy the keen.io API, as the proxy only needs to implement an addEvent POST end-point, not an extra GET end-point. I ran into this problem today when I tried to switch from keen-js to keen-tracking (I use a proxy)
* It's a bit more 'correct' in REST API terms, as POST requests are generally used for updates, not GETs.

Cheers :-)

Greg

**How should this be tested? (if appropriate)**

You got me, guvnor. I didn't write any additional unit tests. I made the behavioural changes, and all the existing tests kept passing:
* run gulp with-tests
* confirm tests pass

I also manually tested all recordEvent cases:
* requestType == 'xhr'
* requestType == 'beacon' / small payload
* requestType == 'beacon' / large payload / xhr-usable
* requestType == 'beacon' / large payload / xhr-not-usable
* requestType == 'jsonp' / large payload / xhr-usable
* requestType == 'jsonp' / large payload / xhr-not-usable

They worked fine.

These changes are mainly a re-org of existing code.

**Are there any related issues open?**

Yes. This PR builds on top of my [earlier 'bug' PR](https://github.com/keen/keen-tracking.js/pull/26)