### PR TITLE
Fix for utilizing library in e.g. React Native and other libraries

### DIFF
--- a/lib/record-events-browser.js
+++ b/lib/record-events-browser.js
@@ -236,7 +236,7 @@ function handleValidationError(message, cb){
 }
 
 function getUrlMaxLength(){
-  if ('undefined' !== typeof window) {
+  if ('undefined' !== typeof window && navigator) {
     if (navigator.userAgent.indexOf('MSIE') !== -1 || navigator.appVersion.indexOf('Trident/') > 0) {
       return 2000;
     }


### PR DESCRIPTION
As title states. Utilizing keen-tracking in React Native is currently hard, as React Native has a window object, but does not have a navigator (for obvious reasons). This would fix the issue. I'm also referencing the following for this:
https://github.com/keen/keen-core.js/pull/7