### PR TITLE
Fix test timeout for auto-tracker

### DIFF
--- a/test/unit/modules/browser-auto-tracking-spec.js
+++ b/test/unit/modules/browser-auto-tracking-spec.js
@@ -5,6 +5,7 @@ var Keen = require('../../../lib/browser');
 describe('Auto Tracking', function() {
 
   beforeEach(function() {
+    this.timeout(5000);
     this.client = new Keen({
       projectId: config.projectId,
       writeKey: config.writeKey,


### PR DESCRIPTION
## What does this PR do?

This PR increases the test `timeout` value for auto-tracker tests.