### PR TITLE
Update Node.js versions of Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - "5.1"
+  - "6"
+  - "8"
 branches:
   only:
     - master


### PR DESCRIPTION
Node.js 5 is EOL, only test against active and LTS versions.