### PR TITLE
Fix subdomain user tracking bug

### DIFF
--- a/lib/browser-auto-tracking.js
+++ b/lib/browser-auto-tracking.js
@@ -21,7 +21,10 @@ function initAutoTracking(lib) {
     var uuid = cookie.get('uuid');
     if (!uuid) {
       uuid = helpers.getUniqueId();
-      cookie.set('uuid', uuid);
+      var domainName = helpers.getDomainName(window.location.host);
+      cookie.set('uuid', uuid, domainName ? {
+        domain: '.' + domainName
+      } : {});
     }
 
     var scrollState = {};

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -34,6 +34,7 @@
   extend(KeenCore.helpers, {
     'getBrowserProfile'  : require('./helpers/getBrowserProfile'),
     'getDatetimeIndex'   : require('./helpers/getDatetimeIndex'),
+    'getDomainName'      : require('./helpers/getDomainName'),
     'getDomNodePath'     : require('./helpers/getDomNodePath'),
     'getDomNodeProfile'  : require('./helpers/getDomNodeProfile'),
     'getScreenProfile'   : require('./helpers/getScreenProfile'),

--- a/lib/helpers/getDomainName.js
+++ b/lib/helpers/getDomainName.js
@@ -1,0 +1,6 @@
+function getDomainName(host){
+  var domainRegex = /\w+\.\w+$/;
+  return domainRegex.test(host) ? host.match(domainRegex)[0] : null;
+}
+
+module.exports = getDomainName;

--- a/test/unit/modules/helpers-spec.js
+++ b/test/unit/modules/helpers-spec.js
@@ -2,6 +2,7 @@ var assert = require('proclaim');
 
 var getBrowserProfile = require('../../../lib/helpers/getBrowserProfile');
 var getDatetimeIndex = require('../../../lib/helpers/getDatetimeIndex');
+var getDomainName = require('../../../lib/helpers/getDomainName');
 var getDomNodePath = require('../../../lib/helpers/getDomNodePath');
 var getDomNodeProfile = require('../../../lib/helpers/getDomNodeProfile');
 var getScreenProfile = require('../../../lib/helpers/getScreenProfile');
@@ -49,6 +50,18 @@ describe('Keen.helpers', function(){
         'month'        : parseInt( 1 + now.getMonth() ),
         'year'         : now.getFullYear()
       });
+    });
+  });
+
+  describe('#getDomainName', function(){
+    it('should return the domain name of a host with a subdomain', function(){
+      assert.equal(getDomainName('subdomain.domain.name'), 'domain.name');
+    });
+    it('should return the domain name of a host with a double subdomain', function(){
+      assert.equal(getDomainName('double.subdomain.domain.name'), 'domain.name');
+    });
+    it('should return null if no domain is found', function(){
+      assert.equal(getDomainName('localhost'), null);
     });
   });
 


### PR DESCRIPTION
## What does this PR do? How does it affect users?

When auto tracking is initialized on a subdomain without having been initialized on the domain, the `keen` cookie is not shared with all other domains. For instance, if a user first visits `subdomain.mywebsite.com` and then `mywebsite.com`, two `keen` cookies are created with different UUIDs. 

This pull request sets the `keen` cookie's `Domain` to the website's domain name prefixed with a `.` so it is always shared with subdomains.

**NOTE:** This technically changes the current behavior of the package.

## How should this be tested?

The new helper function `getDomainName` is unit tested. The cookie's `Domain` property is set by the `js-cookie` module.