### PR TITLE
don't make defer linking with a[download]

### DIFF
--- a/lib/utils/listener.js
+++ b/lib/utils/listener.js
@@ -201,7 +201,7 @@ function deferClickEvent(evt, anchor, callback){
     return false;
   }
   // Else if anchor doesn't kick off a new window or tab.. defer and replay the event:
-  else if (targetAttr !== '_blank' && targetAttr !== 'blank' && !evt.metaKey) {
+  else if (targetAttr !== '_blank' && targetAttr !== 'blank' && !evt.metaKey && !anchor.download) {
     if (evt.preventDefault) {
       evt.preventDefault();
     }

--- a/lib/utils/listener.js
+++ b/lib/utils/listener.js
@@ -201,7 +201,7 @@ function deferClickEvent(evt, anchor, callback){
     return false;
   }
   // Else if anchor doesn't kick off a new window or tab.. defer and replay the event:
-  else if (targetAttr !== '_blank' && targetAttr !== 'blank' && !evt.metaKey && !anchor.download) {
+  else if (targetAttr !== '_blank' && targetAttr !== 'blank' && !evt.metaKey && !anchor.hasAttribute('download')) {
     if (evt.preventDefault) {
       evt.preventDefault();
     }


### PR DESCRIPTION
`a[download]` link (ex: `<a href="example.pdf" download>`) will download file instead of open in browser, but the defer link is breaking it.

When I using it with blob: url, this problem becomes significant.