### PR TITLE
Fix bug when trying to deep extend a string

### DIFF
--- a/lib/utils/deepExtend.js
+++ b/lib/utils/deepExtend.js
@@ -14,6 +14,7 @@ export const deepExtend = function(target){
         // Recurse when both contain objects of same name
         // and incoming is not a null object
         if (typeof target[prop] !== 'undefined'
+          && typeof target[prop] === 'object'
           && typeof arguments[i][prop] === 'object'
           && arguments[i][prop] !== null) {
             deepExtend(target[prop], clone(arguments[i][prop]));


### PR DESCRIPTION

Here is the error 
![keen_bug](https://user-images.githubusercontent.com/8558836/44936393-6f4a1780-ad6c-11e8-9cc6-1b545d8a91b7.png)

## What does this PR do? How does it affect users?
This only fixes a bug with autoTracking.
This adds another check to ensure `target[prop]` is an object. Otherwise `deepExtend` throws.

## How should this be tested?

Step through the code line by line. Things to keep in mind as you review:
 - Are there any edge cases not covered by this code? **No**
 - Does this code follow conventions (naming, formatting, modularization, etc) where applicable? **YES**

Fetch the branch and/or deploy to staging to test the following:

- [x] Does the code compile without warnings (check shell, console)?
- [x] Do all tests pass? (run `gulp with-tests`)
- [x] Does the UI, pixel by pixel, look exactly as expected (check various screen sizes, including mobile)?
- [ ] If the feature makes requests from the browser, inspect them in the Web Inspector. Do they look as expected (parameters, headers, etc)?
- [ ] If the feature sends data to Keen, is the data visible in the project if you run an extraction (include link to collection/query)?
- [ ] If the feature saves data to a database, can you confirm the data is indeed created in the database?

## Related tickets?
