### PR TITLE
Add support for data-event-key attribute on click events

### DIFF
--- a/lib/helpers/getDomNodeProfile.js
+++ b/lib/helpers/getDomNodeProfile.js
@@ -6,6 +6,7 @@ export function getDomNodeProfile(el) {
     class: el.className,
     href: getElementProps(el, 'href'),
     id: getElementProps(el, 'id'),
+    event_key: getElementProps(el, 'data-event-key'),
     method: el.method,
     name: el.name,
     node_name: el.nodeName,


### PR DESCRIPTION
When capturing `clicks` events on the browser side, using  `id` or `class` attributes to identify the source feels less explicit and prone to potential collisions or undesirable tradeoffs.

So this PR is suggesting an additional option using a `data-*` attribute: `data-event-key` which gets captured under the `element.event_key` property.

Usage:
```html
<a href='foo.html' data-event-key="foo-gotten-on-link"><b>Get your foo on!</b></a>
```
```js
// eventObject
{
    ...
    element: {
        ...
        event_key : "foo-gotten-on-link"
    }
}
```

I'm not married to the name.  Change it if there's a more appropriate and short-ish/memorable variant.

We've been trying to use `id` and `class` in-house, but it wasn't clear or maintainable for new team members when using frameworks that move away from using those attributes.