### PR TITLE
Avoid a forced layout during the tracker initialization

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -106,8 +106,8 @@ if (isLocalStorageAvailable && localStorage.getItem('optout')) {
   KeenCore.optedOut = true;
 }
 
-if (getBrowserProfile().doNotTrack === '1'
-  || getBrowserProfile().doNotTrack === 'yes') {
+if (navigator.doNotTrack === '1'
+  || navigator.doNotTrack === 'yes') {
   KeenCore.doNotTrack = true;
 }
 


### PR DESCRIPTION
The initialization only need the doNotTrack info. Computing a full browser profile is useless for that, especially given the cost of the window profile (which requires layout info).

Closes #185 